### PR TITLE
Minor corrections for printf's and README

### DIFF
--- a/src/szatyor/main.cpp
+++ b/src/szatyor/main.cpp
@@ -436,8 +436,8 @@ bool InjectDLL(DWORD processID, const char* dllLocation)
     HMODULE hModule = GetModuleHandle(loadedModuleName);
     if (!hModule)
     {
-        printf("ERROR: Can't get %s's handle, ");
-        printf("ErrorCode: %u\n", loadedModuleName, GetLastError());
+        printf("ERROR: Can't get %s's handle, ",loadedModuleName);
+        printf("ErrorCode: %u\n", GetLastError());
         return false;
     }
 
@@ -445,8 +445,8 @@ bool InjectDLL(DWORD processID, const char* dllLocation)
     FARPROC loadLibraryAddress = GetProcAddress(hModule, loadDLLFunctionName);
     if (!loadLibraryAddress)
     {
-        printf("ERROR: Can't get function %s's address, ");
-        printf("ErrorCode: %u\n", loadDLLFunctionName, GetLastError());
+        printf("ERROR: Can't get function %s's address, ", loadDLLFunctionName);
+        printf("ErrorCode: %u\n",GetLastError());
         return false;
     }
 

--- a/src/szimat/CMakeLists.txt
+++ b/src/szimat/CMakeLists.txt
@@ -36,7 +36,7 @@ if(WIN32)
     # copies the README and COPYING files to the output directory (build/bin)
     add_custom_command(TARGET szimat POST_BUILD COMMAND
                        ${CMAKE_COMMAND} -E copy
-                       ${PROJECT_SOURCE_DIR}/README
+                       ${PROJECT_SOURCE_DIR}/README.md
                        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)/)
     add_custom_command(TARGET szimat POST_BUILD COMMAND
                        ${CMAKE_COMMAND} -E copy


### PR DESCRIPTION
Visual Studio highlighted three errors, two where printf's had been split into two statements but the appropriate strings hadn't been split too. The other was due to README changing to README.md