### PR TITLE
fix error in DumpPacketBinary func

### DIFF
--- a/src/szimat/PacketDump.h
+++ b/src/szimat/PacketDump.h
@@ -249,7 +249,7 @@ private:
         // loops over the packet and saves the data
         for (DWORD i = 0; i < packetSize; ++i)
         {
-            BYTE byte = *(BYTE*)(buffer + initialReadOffset++);
+            BYTE byte = *(BYTE*)(buffer + initialReadOffset + i);
             fwrite(&byte, 1, 1, file);
         }
     }


### PR DESCRIPTION
Packets larger than 0xFFFF bytes were written to the binary file with error, because the initialReadOffset variable has the WORD type, so the data was written cyclically.

Bug was found on the package "ServerToClient: SMSG_AUCTION_LIST_RESULT (0x025C) Length: 8140012".
Parsing bin file with WowPacketParser stops with Exception(System.ArgumentOutOfRangeException) after about 0xFFFF bytes of packet.